### PR TITLE
Use RN 'toHashMap' to convert nested objects

### DIFF
--- a/android/src/main/java/be/smalltownheroes/adobe/analytics/RNAdobeAnalyticsModule.java
+++ b/android/src/main/java/be/smalltownheroes/adobe/analytics/RNAdobeAnalyticsModule.java
@@ -126,30 +126,7 @@ public class RNAdobeAnalyticsModule extends ReactContextBaseJavaModule {
 	}
 
 	private Map<String, Object> convertReadableMapToHashMap(ReadableMap readableMap) {
-		ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
-		HashMap<String, Object> deconstructedMap = new HashMap<>();
-		while (iterator.hasNextKey()) {
-			String key = iterator.nextKey();
-			ReadableType type = readableMap.getType(key);
-			switch (type) {
-				case Null:
-					deconstructedMap.put(key, null);
-					break;
-				case Boolean:
-					deconstructedMap.put(key, readableMap.getBoolean(key));
-					break;
-				case Number:
-					deconstructedMap.put(key, readableMap.getDouble(key));
-					break;
-				case String:
-					deconstructedMap.put(key, readableMap.getString(key));
-					break;
-				default:
-					throw new IllegalArgumentException("Could not convert object with key: " + key + ".");
-			}
-
-		}
-		return deconstructedMap;
+		return readableMap.toHashMap();
 	}
 
 }


### PR DESCRIPTION
Hello there! I recently started using your library in our app at Hive which helped me so much to get Adobe Analytics working quickly. So first of all, thank you for sharing!

The only issue I ran into was a problem with our context object - our analytics team have defined the context as a deeply nested object and that unfortunately wasn't working in Android due to the definition of `convertReadableMapToHashMap`. I checked out the RN interface and saw that they have their own implementation of `toHashMap` which works great in our project.

Any chance we could add this to the package?